### PR TITLE
[#271] Use rubocop 1.57.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Issues are tracked at https://github.com/roberts1000/rubocop_plus/issues. Issues marked as **(Internal)** only affect development.
 
+## Next Release
+
+1. [#271](../../issues/271): Use `rubocop` `1.57.1`.
+
 ## 2.12.0 (Apr 14, 2023)
 
 1. [#256](../../issues/256): Use `rubocop` `1.50.1`.

--- a/lib/rubocop_plus/version.rb
+++ b/lib/rubocop_plus/version.rb
@@ -1,4 +1,4 @@
 module RubocopPlus
   VERSION = "2.12.0".freeze
-  RUBOCOP_VERSION = '1.50.1'.freeze
+  RUBOCOP_VERSION = '1.57.1'.freeze
 end


### PR DESCRIPTION
<-- Replace XYZ with the related GitHub issue number -->

Closes #271
