### PR TITLE
Use rubocop-performance 1.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Issues are tracked at https://github.com/roberts1000/rubocop_plus/issues. Issues
 
 1. [#324](../../issues/324): Use `rubocop-rspec` `0.7.1`.
 1. [#325](../../issues/325): Use `rubocop` `1.72.2`.
+1. [#328](../../issues/328): Use `rubocop-performance` `1.24.0`.
 
 ## 2.16.0 (Aug 11, 2024)
 

--- a/rubocop_plus.gemspec
+++ b/rubocop_plus.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "cri", "~> 2.0"
   spec.add_dependency "rubocop", RubocopPlus::RUBOCOP_VERSION.to_s
-  spec.add_dependency "rubocop-performance", "1.21.1"
+  spec.add_dependency "rubocop-performance", "1.24.0"
   spec.add_dependency "rubocop-rails", "2.25.1"
   spec.add_dependency "rubocop-rake", "0.7.1"
   spec.add_dependency "rubocop-rspec", "3.0.4"


### PR DESCRIPTION
<!-- Replace XYZ with the related GitHub issue number -->

Closes #328 