### PR TITLE
Exclude spec/rails_helper.rb from Rails/RootPathnameMethods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Issues are tracked at https://github.com/roberts1000/rubocop_plus/issues. Issues
 1. [#342](../../issues/342): Add Ruby 3.4 support.
 1. [#344](../../issues/344): Remove `RSpec/FilePath` configuration.
 1. [#346](../../issues/346): Set `RSpec/ExampleLength` to 15.
+1. [#348](../../issues/348): Exclude `spec/rails_helper.rb` from `Rails/RootPathnameMethods`.
 
 ## 2.16.0 (Aug 11, 2024)
 

--- a/config/group/rails.yml
+++ b/config/group/rails.yml
@@ -8,3 +8,7 @@ Rails/FilePath:
 
 Performance/RedundantMerge:
   Enabled: false
+
+Rails/RootPathnameMethods:
+  Exclude:
+    - spec/rails_helper.rb # See https://github.com/roberts1000/rubocop_plus/issues/348


### PR DESCRIPTION
<!-- Replace XYZ with the related GitHub issue number -->

Closes #348