### PR TITLE
Use rubocop 1.78.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Issues are tracked at https://github.com/roberts1000/rubocop_plus/issues. Issues marked as **(Internal)** only affect development.
 
+## Next Release
+
+1. [#361](../../issues/361): Use `rubocop` `1.78.0`.
+
 ## 2.17.0 (Feb 28, 2025)
 
 1. [#324](../../issues/324): Use `rubocop-rspec` `0.7.1`.

--- a/lib/rubocop_plus/version.rb
+++ b/lib/rubocop_plus/version.rb
@@ -1,4 +1,4 @@
 module RubocopPlus
   VERSION = "2.17.0".freeze
-  RUBOCOP_VERSION = '1.73.1'.freeze
+  RUBOCOP_VERSION = '1.78.0'.freeze
 end


### PR DESCRIPTION
<!-- Replace XYZ with the related GitHub issue number -->

Closes #361