### PR TITLE
Use rubocop-performance 1.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Issues are tracked at https://github.com/roberts1000/rubocop_plus/issues. Issues
 ## Next Release
 
 1. [#381](../../issues/381): Use `rubocop` `1.80.1.`
+1. [#383](../../issues/383): Use `rubocop-performance` `1.26.0.`
 
 ## 2.18.0 (Jul 15, 2025)
 

--- a/rubocop_plus.gemspec
+++ b/rubocop_plus.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rubocop", RubocopPlus::RUBOCOP_VERSION.to_s
   spec.add_dependency "rubocop-capybara", "2.22.1"
   spec.add_dependency "rubocop-factory_bot", "2.27.1"
-  spec.add_dependency "rubocop-performance", "1.25.0"
+  spec.add_dependency "rubocop-performance", "1.26.0"
   spec.add_dependency "rubocop-rails", "2.32.0"
   spec.add_dependency "rubocop-rake", "0.7.1"
   spec.add_dependency "rubocop-rspec", "3.6.0"


### PR DESCRIPTION
<!-- Replace XYZ with the related GitHub issue number -->

Closes #383 