### PR TITLE
Use rubocop-performance 1.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Issues are tracked at https://github.com/roberts1000/rubocop_plus/issues. Issues
 1. [#391](../../issues/391): Allow `bundler` `>= 2.0`.
 1. [#393](../../issues/393): Use `rubocop` `1.82.1`.
 1. [#395](../../issues/395): Use `rubocop-factory_bot` `2.28.0`.
+1. [#397](../../issues/397): Use `rubocop-performance` `2.26.1`.
 
 ## 2.19.0 (Oct 10, 2025)
 

--- a/rubocop_plus.gemspec
+++ b/rubocop_plus.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rubocop", RubocopPlus::RUBOCOP_VERSION.to_s
   spec.add_dependency "rubocop-capybara", "2.22.1"
   spec.add_dependency "rubocop-factory_bot", "2.28.0"
-  spec.add_dependency "rubocop-performance", "1.26.0"
+  spec.add_dependency "rubocop-performance", "1.26.1"
   spec.add_dependency "rubocop-rails", "2.33.4"
   spec.add_dependency "rubocop-rake", "0.7.1"
   spec.add_dependency "rubocop-rspec", "3.7.0"


### PR DESCRIPTION
<!-- Replace XYZ with the related GitHub issue number -->

Closes #397 