### PR TITLE
Use rubocop 1.86.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Issues are tracked at https://github.com/roberts1000/rubocop_plus/issues. Issues marked as **(Internal)** only affect development.
 
+## Next Release
+
+1. [#413](../../issues/413): Use `rubocop` `1.86.2`.
+
 ## 2.20.0 (Jan 25, 2026)
 
 1. [#391](../../issues/391): Allow `bundler` `>= 2.0`.

--- a/lib/rubocop_plus/version.rb
+++ b/lib/rubocop_plus/version.rb
@@ -1,4 +1,4 @@
 module RubocopPlus
   VERSION = "2.20.0".freeze
-  RUBOCOP_VERSION = '1.82.1'.freeze
+  RUBOCOP_VERSION = '1.86.2'.freeze
 end


### PR DESCRIPTION
<!-- Replace XYZ with the related GitHub issue number -->

Closes #413 
