### PR TITLE
Use rubocop-rails 2.35.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Issues are tracked at https://github.com/roberts1000/rubocop_plus/issues. Issues
 ## Next Release
 
 1. [#425](../../issues/425): Use `rubocop` `1.87.0`.
+1. [#427](../../issues/427): Use `rubocop-rails` `2.35.3`.
 
 ## 2.21.0 (Jun 06, 2026)
 

--- a/rubocop_plus.gemspec
+++ b/rubocop_plus.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rubocop-capybara", "2.23.0"
   spec.add_dependency "rubocop-factory_bot", "2.28.0"
   spec.add_dependency "rubocop-performance", "1.26.1"
-  spec.add_dependency "rubocop-rails", "2.35.2"
+  spec.add_dependency "rubocop-rails", "2.35.3"
   spec.add_dependency "rubocop-rake", "0.7.1"
   spec.add_dependency "rubocop-rspec", "3.9.0"
   spec.add_dependency "rubocop-rspec_rails", "2.32.0"


### PR DESCRIPTION
<!-- Replace XYZ with the related GitHub issue number -->

Closes #427 