### PR TITLE
Use rubocop-rails 2.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Issues are tracked at https://github.com/roberts1000/rubocop_plus/issues. Issues
 
 1. [#437](../../issues/437): Use `rubocop` `1.88.2`.
 1. [#439](../../issues/439): Use `rubocop-capybara` `3.0.0`.
+1. [#441](../../issues/441): Use `rubocop-rails` `2.36.0`.
 
 ## 2.22.1 (Jun 06, 2026)
 

--- a/rubocop_plus.gemspec
+++ b/rubocop_plus.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rubocop-capybara", "3.0.0"
   spec.add_dependency "rubocop-factory_bot", "2.28.0"
   spec.add_dependency "rubocop-performance", "1.26.1"
-  spec.add_dependency "rubocop-rails", "2.35.4"
+  spec.add_dependency "rubocop-rails", "2.36.0"
   spec.add_dependency "rubocop-rake", "0.7.1"
   spec.add_dependency "rubocop-rspec", "3.10.2"
   spec.add_dependency "rubocop-rspec_rails", "2.32.0"


### PR DESCRIPTION
<!-- Replace XYZ with the related GitHub issue number -->

Closes #441 
